### PR TITLE
Add new plug option: :repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## master
+  *
+    * Add `repo` as an override option to the plugs
+
 ## v1.1.0
   * Enhancements
     * Add `non_id_actions` opt

--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ instead of
 /posts/1
 ```
 
+### Repo override
+
+You can tell Canary to use a different Repo by using the `:repo` option.
+
+For example, if you want to use the `YourApp.Other.Repo` in your controller instead of the default provided in the config:
+
+```elixir
+plug :load_and_authorize_resource, model: Post, repo: YourApp.Other.Repo
+```
+
 ### Handling unauthorized actions
 
 By default, when an action is unauthorized, Canary simply sets `conn.assigns.authorized` to `false`.

--- a/lib/canary/plugs.ex
+++ b/lib/canary/plugs.ex
@@ -70,6 +70,7 @@ defmodule Canary.Plugs do
   * `:id_field` - Specifies the name of the ID field in the database for searching :id_name value, defaults to "id".
   * `:persisted` - Specifies the resource should always be loaded from the database, defaults to false
   * `:not_found_handler` - Specify a handler function to be called if the resource is not found
+  * `:repo` - Specify an Ecto Repo to use instead of the default provided in the config
 
   Examples:
   ```
@@ -84,6 +85,8 @@ defmodule Canary.Plugs do
   plug :load_resource, model: Post, id_name: "post_id", only: [:new, :create], persisted: true
 
   plug :load_resource, model: Post, id_name: "slug", id_field: "slug", only: [:show], persisted: true
+
+  plug :load_resource, model: Post, repo: YourApp.Other.Repo
   ```
   """
   def load_resource(conn, opts) do
@@ -229,6 +232,7 @@ defmodule Canary.Plugs do
   * `:id_field` - Specifies the name of the ID field in the database for searching :id_name value, defaults to "id".
   * `:persisted` - Specifies the resource should always be loaded from the database, defaults to false
   * `:unauthorized_handler` - Specify a handler function to be called if the action is unauthorized
+  * `:repo` - Specify an Ecto Repo to use instead of the default provided in the config
 
   Examples:
   ```
@@ -238,9 +242,11 @@ defmodule Canary.Plugs do
 
   plug :authorize_resource, model: User, only: [:index, :show], preload: :posts
 
-  plug :load_resource, model: Post, id_name: "post_id", only: [:index], persisted: true, preload: :comments
+  plug :authorize_resource, model: Post, id_name: "post_id", only: [:index], persisted: true, preload: :comments
 
-  plug :load_resource, model: Post, id_name: "slug", id_field: "slug", only: [:show], persisted: true
+  plug :authorize_resource, model: Post, id_name: "slug", id_field: "slug", only: [:show], persisted: true
+
+  plug :authorize_resource, model: Post, repo: YourApp.Other.Repo
   ```
   """
   def authorize_resource(conn, opts) do
@@ -302,6 +308,7 @@ defmodule Canary.Plugs do
   * `:id_field` - Specifies the name of the ID field in the database for searching :id_name value, defaults to "id".
   * `:unauthorized_handler` - Specify a handler function to be called if the action is unauthorized
   * `:not_found_handler` - Specify a handler function to be called if the resource is not found
+  * `:repo` - Specify an Ecto Repo to use instead of the default provided in the config
 
   Note: If both an `:unauthorized_handler` and a `:not_found_handler` are specified for `load_and_authorize_resource`,
   and the request meets the criteria for both, the `:unauthorized_handler` will be called first.
@@ -317,6 +324,8 @@ defmodule Canary.Plugs do
   plug :load_and_authorize_resource, model: User, except: [:destroy]
 
   plug :load_and_authorize_resource, model: Post, id_name: "slug", id_field: "slug", only: [:show], persisted: true
+
+  plug :load_and_authorize_resource, model: Post, repo: YourApp.Other.Repo
   ```
   """
   def load_and_authorize_resource(conn, opts) do
@@ -347,7 +356,7 @@ defmodule Canary.Plugs do
     do: Plug.Conn.assign(conn, get_resource_name(conn, opts), nil)
 
   defp fetch_resource(conn, opts) do
-    repo = Application.get_env(:canary, :repo)
+    repo = Keyword.get(opts, :repo, Application.get_env(:canary, :repo))
 
     field_name = Keyword.get(opts, :id_field, "id")
 

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -40,6 +40,11 @@ defmodule Repo do
   def get_by(Post, %{slug: _}), do: nil
 end
 
+defmodule OtherRepo do
+  def get_by(User, %{id: 2}), do: %User{id: 2}
+  #def get(User, 2), do: %User{id: 2}
+end
+
 defimpl Canada.Can, for: User do
 
   def can?(%User{}, action, Myproject.PartialAccessController)
@@ -225,6 +230,16 @@ defmodule PlugTest do
     params = %{"user_id" => 1}
     conn = conn(%Plug.Conn{private: %{phoenix_action: :create}}, :post, "/users/1/posts", params)
     expected = Plug.Conn.assign(conn, :user, %User{id: 1})
+
+    assert load_resource(conn, opts) == expected
+  end
+
+  test "it loads the resource correctly from the other repo" do
+    opts = [model: User, repo: OtherRepo]
+
+    params = %{"id" => 2}
+    conn = conn(%Plug.Conn{private: %{phoenix_action: :show}}, :get, "/users/2", params)
+    expected = Plug.Conn.assign(conn, :user, %User{id: 2})
 
     assert load_resource(conn, opts) == expected
   end


### PR DESCRIPTION
When using the plug, support a `:repo` option that when used will
override the default repo from the configuration.

This can be used in applications that use different repos (databases) in
different controller actions.